### PR TITLE
Stop using adb internals to start a proc

### DIFF
--- a/lib/uiautomator.js
+++ b/lib/uiautomator.js
@@ -1,5 +1,4 @@
 import events from 'events';
-import { SubProcess } from 'teen_process';
 import { getLogger } from 'appium-logger';
 
 
@@ -29,10 +28,9 @@ class UiAutomator extends events.EventEmitter {
       // killing any uiautomator existing processes
       await this.killUiAutomatorOnDevice();
 
+      log.debug('Starting UIAutomator');
       let args = ["shell", "uiautomator", "runtest", jarName, "-c", className, ...extraParams];
-      const adbPath = this.adb.getAdbPath();
-      log.debug(`Executing command ${adbPath} ${args}`);
-      this.proc = new SubProcess(adbPath, args);
+      this.proc = this.adb.createSubProcess(args);
 
       // handle out-of-bound exit by simply emitting a stopped state
       this.proc.on('exit', (code, signal) => {

--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   ],
   "homepage": "https://github.com/appium/appium-uiautomator",
   "dependencies": {
-    "appium-adb": "^2.0.1",
+    "appium-adb": "^2.2.2",
     "appium-logger": "^2.0.0",
     "babel-runtime": "=5.8.24",
-    "source-map-support": "^0.3.2",
-    "teen_process": "^1.3.1"
+    "source-map-support": "^0.3.2"
   },
   "devDependencies": {
     "appium-gulp-plugins": "^1.3.11",
     "appium-test-support": "0.0.5",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "gulp": "^3.8.11"
+    "gulp": "^3.8.11",
+    "teen_process": "^1.3.1"
   }
 }


### PR DESCRIPTION
Allow `appium-adb` to give us the SubProcess.
