### PR TITLE
Do not stop the subprocess if it has already stopped itself.

### DIFF
--- a/lib/uiautomator.js
+++ b/lib/uiautomator.js
@@ -63,8 +63,10 @@ class UiAutomator extends events.EventEmitter {
 
   async shutdown () {
     log.debug('Shutting down UiAutomator');
-    this.changeState(UiAutomator.STATE_STOPPING);
-    await this.proc.stop();
+    if (this.state !== UiAutomator.STATE_STOPPED) {
+      this.changeState(UiAutomator.STATE_STOPPING);
+      await this.proc.stop();
+    }
     await this.killUiAutomatorOnDevice();
     this.changeState(UiAutomator.STATE_STOPPED);
   }


### PR DESCRIPTION
This is a pull request to deal with issue: https://github.com/appium/appium/issues/10785 .

I wasn't sure what to do about the killing of leaked uiautomator processes. It doesn't happen when it detects an unexpected termination of the process, so I left it in, in the showtdown.